### PR TITLE
Fixed start date for the Meiji era

### DIFF
--- a/kanjidate.js
+++ b/kanjidate.js
@@ -92,7 +92,7 @@ function toGengou(year, month, day){
 	if( ge(year, month, day, 1912, 7, 30) ){
 		return { gengou:"大正", nen:year - 1911 };
 	}
-	if( ge(year, month, day, 1873, 1, 1) ){
+	if( ge(year, month, day, 1868, 10, 23) ){
 		return { gengou: "明治", nen: year - 1867 };
 	}
 	return { gengou: "西暦", nen: year };

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,7 @@ describe("convert to gengou", function(){
 	});
 	it("calculate gengou from year, month and day", function(){
 		expect(kanjidate.toGengou(1879, 9, 12)).to.eql({gengou: "明治", nen: 12})
+		expect(kanjidate.toGengou(1868, 10, 25)).to.eql({gengou: "明治", nen: 1})
 	});
 	it("calculate gengou from year, month and day", function(){
 		expect(kanjidate.toGengou(1857, 9, 12)).to.eql({gengou: "西暦", nen: 1857})


### PR DESCRIPTION
The Meiji era should start from October 23, 1868, not from January 1, 1873. That error was lead to formatting 1869-10-11 as "西暦69年10月11日", not "明治69年10月11日". Note that the "nen" property for dates after 1873 was calculated correctly.

Added test.

Refer to https://en.wikipedia.org/wiki/Meiji_(era)